### PR TITLE
Update: use custom jre

### DIFF
--- a/apps/qa-tool/Dockerfile
+++ b/apps/qa-tool/Dockerfile
@@ -1,6 +1,40 @@
-FROM amazoncorretto:17
+# create dependencies to create custom jre
+FROM amazoncorretto:17 as deps
 
 WORKDIR /app
 COPY ./target/*.jar /app/app.jar
+
+RUN set -eux; \
+    "$JAVA_HOME"/bin/jar -xf app.jar && \
+    "$JAVA_HOME"/bin/jdeps \
+    --ignore-missing-deps \
+    -q \
+    --multi-release 17 \
+    --recursive \
+    --print-module-deps \
+    --class-path="./BOOT-INF/lib/*" \
+    --module-path="./BOOT-INF/lib/*" \
+    ./app.jar > jre-deps.info
+
+# create custom jre
+FROM amazoncorretto:17 as jre-builder
+
+WORKDIR /app
+COPY --from=deps /app/jre-deps.info jre-deps.info
+RUN set -eux; \
+    "$JAVA_HOME"/bin/jlink --verbose \
+    --compress 2 \
+    --strip-java-debug-attributes \
+    --no-header-files \
+    --no-man-pages \
+    --output jre \
+    --add-modules "$(cat jre-deps.info)"
+
+FROM debian:buster-20240130-slim
+ENV JAVA_HOME /opt/java/openjdk
+ENV PATH $JAVA_HOME/bin:$PATH
+WORKDIR /app
+COPY --from=jre-builder /app/jre $JAVA_HOME
+COPY --from=deps /app/app.jar app.jar
 
 ENTRYPOINT [ "java", "-jar", "/app/app.jar" ]

--- a/apps/tool-manager/Dockerfile
+++ b/apps/tool-manager/Dockerfile
@@ -1,6 +1,40 @@
-FROM amazoncorretto:17
+# create dependencies to create custom jre
+FROM amazoncorretto:17 as deps
 
 WORKDIR /app
 COPY ./target/*.jar /app/app.jar
+
+RUN set -eux; \
+    "$JAVA_HOME"/bin/jar -xf app.jar && \
+    "$JAVA_HOME"/bin/jdeps \
+    --ignore-missing-deps \
+    -q \
+    --multi-release 17 \
+    --recursive \
+    --print-module-deps \
+    --class-path="./BOOT-INF/lib/*" \
+    --module-path="./BOOT-INF/lib/*" \
+    ./app.jar > jre-deps.info
+
+# create custom jre
+FROM amazoncorretto:17 as jre-builder
+
+WORKDIR /app
+COPY --from=deps /app/jre-deps.info jre-deps.info
+RUN set -eux; \
+    "$JAVA_HOME"/bin/jlink --verbose \
+    --compress 2 \
+    --strip-java-debug-attributes \
+    --no-header-files \
+    --no-man-pages \
+    --output jre \
+    --add-modules "$(cat jre-deps.info)"
+
+FROM debian:buster-20240130-slim
+ENV JAVA_HOME /opt/java/openjdk
+ENV PATH $JAVA_HOME/bin:$PATH
+WORKDIR /app
+COPY --from=jre-builder /app/jre $JAVA_HOME
+COPY --from=deps /app/app.jar app.jar
 
 ENTRYPOINT [ "java", "-jar", "/app/app.jar" ]


### PR DESCRIPTION
## Descriptions

Improved dockerization process to use custom JRE. The image size of tool-manager was reduced to 178MB from 552MB.
Although I could reduce the image size more to use alpine image, it is a bit hard to build and maintain libs. I think debian-slim is enough.